### PR TITLE
Fix loading of structuredefinition_elements so that unscoped searches work

### DIFF
--- a/schema/201502270000_metadata_up.sql
+++ b/schema/201502270000_metadata_up.sql
@@ -36,7 +36,7 @@ func! load_elements(_prof_ jsonb) returns text
       x->>'comments',
       x->>'isSummary' = 'true',
       (
-        SELECT array_agg(this.structuredefinition_to_resource_type(y->>'structuredefinition'))
+        SELECT array_agg(this.structuredefinition_to_resource_type(y->>'profile'))
          FROM jsonb_array_elements(x->'type') y
          WHERE y->>'code' = 'Reference'
       )


### PR DESCRIPTION
Loading of structuredefinition_elements is currently not loading the ref_type properly as its using 'structuredefinition' as the key to identify the type instead of 'profile'.
For example, the below unscoped search generates a wrong SQL
select fhir.search_sql('Encounter','patient.name=Cho&patient.organization.name=Mollis');
whereas the below identical scoped search generates the valid SQL
select fhir.search_sql('Encounter','patient:Patient.name=Cho&patient:Patient.organization:Organization.name=Mollis');