### PR TITLE
Fix broken link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ History](https://www.hl7.org/fhir/http.html#history).
 ## Getting Started
 
 Please proceed to the [Getting
-Started](https://fhirbase.gitbook.io/project/getting-started) tutorial
+Started](https://fhirbase.aidbox.app/getting-started) tutorial
 for PostgreSQL and Fhirbase installation instructions.
 
 ## Usage Statistics


### PR DESCRIPTION
https://fhirbase.gitbook.io no longer exists; I think the link I suggest here is an appropriate replacement. (This is the only reference to https://fhirbase.gitbook.io in the repo; I checked.)